### PR TITLE
elite request: crDroid-op6 for Android 13

### DIFF
--- a/elite/13/crDroid-op6/crDroid-op6.config
+++ b/elite/13/crDroid-op6/crDroid-op6.config
@@ -1,0 +1,132 @@
+# NikGapps configuration file
+
+# If you are not sure about the config, just skip making changes to it or comment it by adding # before it
+# visit https://nikgapps.com/misc/2020/11/22/NikGapps-Config.html to read everything about nikgapps
+
+AndroidVersion=13
+
+Version=28
+
+# set this to the directory you want to copy the logs to.
+# for e.g. LogDirectory="/system/etc" will install the logs to /system/etc/nikgapps_logs directory
+# by default it will install it to /sdcard/NikGapps/nikgapps_logs
+LogDirectory="/system/etc"
+
+# set to /system, /product or /system_ext if you want to force the installation to aforementioned locations
+InstallPartition=default
+
+# set to uninstall if you want to uninstall any google app, also set the value of google app below to -1
+mode=install
+
+# set WipeDalvikCache=0 if you don't want the installer to wipe dalvik/cache after installing the gapps
+WipeDalvikCache=1
+
+# set WipeRuntimePermissions=1 if you want to wipe runtime permissions
+WipeRuntimePermissions=0
+
+# Addon.d config set it to 0 to skip the automatic backup/restore while flashing the rom
+execute.d=1
+
+# if you want to force the installer to use the config from gapps zip file, set below to 1
+use_zip_config=1
+
+# set this to 1 if you want to enable gms optimization, careful while doing it, you may experience issues like delayed notification with some Roms
+gms_optimization=0
+
+# Following are the packages with default configuration
+
+# Set Core=0 if you want to skip installing all packages belonging to Core Package
+Core=1
+>>ExtraFiles=1
+>>GooglePlayStore=1
+>>GoogleServicesFramework=1
+>>GoogleContactsSyncAdapter=1
+>>GoogleCalendarSyncAdapter=1
+>>GmsCore=1
+
+DigitalWellbeing=0
+GoogleMessages=0
+GoogleDialer=0
+GoogleContacts=0
+CarrierServices=0
+GoogleClock=0
+
+# Set SetupWizard=0 if you want to skip installing all packages belonging to SetupWizard Package
+SetupWizard=1
+>>SetupWizard=1
+>>GoogleRestore=1
+>>GoogleOneTimeInitializer=1
+
+GoogleCalculator=0
+Drive=0
+GoogleMaps=0
+GoogleLocationHistory=0
+GooglePhotos=0
+DeviceHealthServices=0
+GBoard=0
+GoogleCalendar=0
+GoogleKeep=0
+PlayGames=0
+
+# Set PixelLauncher=0 if you want to skip installing all packages belonging to PixelLauncher Package
+PixelLauncher=0
+>>PixelLauncher=0
+>>DevicePersonalizationServices=0
+>>QuickAccessWallet=0
+>>GoogleWallpaper=0
+>>SettingsServices=0
+>>PrivateComputeServices=0
+>>PixelThemes=0
+
+
+# Set GoogleFiles=0 if you want to skip installing all packages belonging to GoogleFiles Package
+GoogleFiles=0
+>>GoogleFiles=0
+>>StorageManager=0
+>>DocumentsUIGoogle=0
+
+GoogleRecorder=0
+MarkupGoogle=1
+GoogleTTS=1
+
+# Set GoogleSearch=0 if you want to skip installing all packages belonging to GoogleSearch Package
+GoogleSearch=1
+>>Velvet=1
+>>Assistant=1
+
+GoogleSounds=0
+
+# Set GoogleChrome=0 if you want to skip installing all packages belonging to GoogleChrome Package
+GoogleChrome=0
+>>GoogleChrome=0
+>>WebViewGoogle=0
+>>TrichromeLibrary=0
+
+Gmail=0
+DeviceSetup=0
+AndroidAuto=1
+GoogleFeedback=0
+GooglePartnerSetup=0
+AndroidDevicePolicy=0
+# Set CoreGo=0 if you want to skip installing all packages belonging to CoreGo Package
+CoreGo=0
+
+# Setting CoreGo=0 will not skip following packages, set them to 0 if you want to skip them
+GoogleGo=0
+AssistantGo=0
+MapsGo=0
+NavigationGo=0
+GalleryGo=0
+GmailGo=0
+
+# Following are the Addon packages NikGapps supports
+GoogleFi=0
+GoogleDuo=0
+GoogleDocs=0
+GoogleSlides=0
+GoogleSheets=0
+YouTube=0
+YouTubeMusic=0
+Books=0
+PixelSetupWizard=0
+GoogleTalkback=0


### PR DESCRIPTION
Hi there, my name is Jordan and I'm the current maintainer for crDroid Android custom ROM for the OnePlus 6-series.
I would like to apply for creating recurring automatic "elite" builds using a custom config for my users.

As we do not ship Google Apps built-in, I've been testing several different packages, and have been testing & recommending NikGapps on multiple versions of Android, and as the preferred recommendation for Android 13 since MindTheGapps has had some permissions issues resulting in excessive battery drain early on.

I've been linking personal builds with a custom config file for several months now, in order to save time installing (since adb sideloading multiple packages to a slow, lineage-based recovery can be... onerous).

Huge thank you to Nikhil & team for the work on this project, and now for inviting me to test automatic package building!