### PR TITLE
elite: Update config for crDroid-op6:13

### DIFF
--- a/elite/13/crDroid-op6/crDroid-op6.config
+++ b/elite/13/crDroid-op6/crDroid-op6.config
@@ -13,7 +13,7 @@ Version=28
 # set this to the directory you want to copy the logs to.
 # for e.g. LogDirectory="/system/etc" will install the logs to /system/etc/nikgapps_logs directory
 # by default it will install it to /sdcard/NikGapps/nikgapps_logs
-LogDirectory="/system/etc"
+LogDirectory=/system/etc
 
 # set to /system, /product or /system_ext if you want to force the installation to aforementioned locations
 InstallPartition=default
@@ -51,7 +51,7 @@ DigitalWellbeing=0
 GoogleMessages=0
 GoogleDialer=0
 GoogleContacts=0
-CarrierServices=0
+CarrierServices=1
 GoogleClock=0
 
 # Set SetupWizard=0 if you want to skip installing all packages belonging to SetupWizard Package
@@ -65,7 +65,7 @@ Drive=0
 GoogleMaps=0
 GoogleLocationHistory=0
 GooglePhotos=0
-DeviceHealthServices=0
+DeviceHealthServices=1
 GBoard=0
 GoogleCalendar=0
 GoogleKeep=0
@@ -73,13 +73,13 @@ PlayGames=0
 
 # Set PixelLauncher=0 if you want to skip installing all packages belonging to PixelLauncher Package
 PixelLauncher=0
->>PixelLauncher=0
->>DevicePersonalizationServices=0
->>QuickAccessWallet=0
->>GoogleWallpaper=0
->>SettingsServices=0
->>PrivateComputeServices=0
->>PixelThemes=0
+>>PixelLauncher=1
+>>DevicePersonalizationServices=1
+>>QuickAccessWallet=1
+>>GoogleWallpaper=1
+>>SettingsServices=1
+>>PrivateComputeServices=1
+>>PixelThemes=1
 
 
 # Set GoogleFiles=0 if you want to skip installing all packages belonging to GoogleFiles Package
@@ -101,15 +101,15 @@ GoogleSounds=0
 
 # Set GoogleChrome=0 if you want to skip installing all packages belonging to GoogleChrome Package
 GoogleChrome=0
->>GoogleChrome=0
->>WebViewGoogle=0
->>TrichromeLibrary=0
+>>GoogleChrome=1
+>>WebViewGoogle=1
+>>TrichromeLibrary=1
 
 Gmail=0
-DeviceSetup=0
+DeviceSetup=1
 AndroidAuto=1
 GoogleFeedback=0
-GooglePartnerSetup=0
+GooglePartnerSetup=1
 AndroidDevicePolicy=0
 # Set CoreGo=0 if you want to skip installing all packages belonging to CoreGo Package
 CoreGo=0


### PR DESCRIPTION
Fix:
* Remove quotes around install log path
* No need to set AppSet Packages to zero

Packages:
* Add DeviceSetup, GooglePartnerSetup, DeviceHealthServices, and CarrierServices