### PR TITLE
elite: Fixup! Update crDroid-op6:13

### DIFF
--- a/elite/13/crDroid-op6/crDroid-op6.config
+++ b/elite/13/crDroid-op6/crDroid-op6.config
@@ -7,13 +7,13 @@ PR_NAME=Terminator-J
 
 AndroidVersion=13
 
-RELEASE_DATE=2306091657
+RELEASE_DATE=2306090420
 Version=28
 
 # set this to the directory you want to copy the logs to.
 # for e.g. LogDirectory="/system/etc" will install the logs to /system/etc/nikgapps_logs directory
 # by default it will install it to /sdcard/NikGapps/nikgapps_logs
-LogDirectory=/system/etc
+LogDirectory=default
 
 # set to /system, /product or /system_ext if you want to force the installation to aforementioned locations
 InstallPartition=default


### PR DESCRIPTION
Fix:
* Use default LogDirectory path (in Lineage-based recovery, it will save a copy in current slot's system/etc/ already, don't need to workaround)

* Trigger rebuild by setting RELEASE_DATE to earlier timestamp

(sorry for the flurry of updates, think I've got it now)