### PR TITLE
Update alphadroid.config

### DIFF
--- a/elite/13/alphadroid_davinci/alphadroid.config
+++ b/elite/13/alphadroid_davinci/alphadroid.config
@@ -56,9 +56,9 @@ GoogleClock=0
 
 # Set SetupWizard=0 if you want to skip installing all packages belonging to SetupWizard Package
 SetupWizard=0
->>SetupWizard=0
->>GoogleRestore=0
->>GoogleOneTimeInitializer=0
+>>SetupWizard=1
+>>GoogleRestore=1
+>>GoogleOneTimeInitializer=1
 
 GoogleCalculator=1
 Drive=0


### PR DESCRIPTION
* Pixelsetupwizard doesn't work when the sub components are disabled.