### PR TITLE
So you do setup wizard config like this? (I want pixel setup wizard)

### DIFF
--- a/10/noobhitler.config
+++ b/10/noobhitler.config
@@ -1,0 +1,138 @@
+# NikGapps configuration file
+
+# If you are not sure about the config, just skip making changes to it or comment it by adding # before it
+# visit https://nikgapps.com/misc/2022/02/22/NikGapps-Config.html to read everything about nikgapps
+
+AndroidVersion=10
+
+Version=35
+
+# set this to the directory you want to copy the logs to.
+# for e.g. LogDirectory="/system/etc" will install the logs to /system/etc/nikgapps_logs directory
+# by default it will install it to /sdcard/NikGapps/nikgapps_logs
+LogDirectory=default
+
+# set to /system, /product or /system_ext if you want to force the installation to aforementioned locations
+InstallPartition=default
+
+# set to uninstall if you want to uninstall any google app, also set the value of google app below to -1
+Mode=install
+
+# set WipeDalvikCache=0 if you don't want the installer to wipe dalvik/cache after installing the gapps
+WipeDalvikCache=1
+
+# set WipeRuntimePermissions=1 if you want to wipe runtime permissions
+WipeRuntimePermissions=0
+
+# Addon.d config, set it to 0 to skip the automatic backup/restore while flashing the rom
+ExecuteBackupRestore=1
+
+# if you want to force the installer to use the config from gapps zip file, set below to 1
+UseZipConfig=0
+
+# if you want to overwrite the config located in /sdcard/NikGapps with gapps zip file, set below to 1. Applicable to decrypted storage only
+OverwriteWithZipConfig=0
+
+# set this to 1 if you want to enable gms optimization, careful while doing it, you may experience issues like delayed notification with some Roms
+GmsOptimization=0
+
+# set this to 0 if you want to skip generating nikgapps logs, if you run into issues, enable it and flash the zip again to get the logs
+GenerateLogs=0
+
+# Following are the packages with default configuration
+
+# Set Core=0 if you want to skip installing all packages belonging to Core Package
+Core=1
+>>ExtraFiles=1
+>>GooglePlayStore=1
+>>GoogleServicesFramework=1
+>>GoogleContactsSyncAdapter=1
+>>GoogleCalendarSyncAdapter=1
+>>GmsCore=1
+
+DigitalWellbeing=1
+GoogleMessages=1
+GoogleDialer=1
+GoogleContacts=1
+CarrierServices=1
+GoogleClock=1
+
+# Set SetupWizard=0 if you want to skip installing all packages belonging to SetupWizard Package
+SetupWizard=1
+>>SetupWizard=1
+>>GoogleRestore=1
+>>GoogleOneTimeInitializer=1
+>>AndroidMigratePrebuilt=1
+
+GoogleCalculator=0
+Drive=0
+GoogleMaps=0
+GooglePhotos=0
+DeviceHealthServices=0
+GBoard=1
+GoogleCalendar=0
+GoogleKeep=0
+
+# Set PixelSpecifics=0 if you want to skip installing all packages belonging to PixelSpecifics Package
+PixelSpecifics=1
+>>PixelLauncher=0
+>>DevicePersonalizationServices=0
+>>GoogleWallpaper=1
+
+PlayGames=0
+GoogleRecorder=0
+
+# Set GoogleFiles=0 if you want to skip installing all packages belonging to GoogleFiles Package
+GoogleFiles=1
+>>GoogleFiles=1
+>>StorageManager=1
+
+MarkupGoogle=0
+GoogleTTS=0
+
+# Set GoogleSearch=0 if you want to skip installing all packages belonging to GoogleSearch Package
+GoogleSearch=1
+>>Velvet=1
+>>Assistant=1
+
+GoogleSounds=1
+
+# Set GoogleChrome=0 if you want to skip installing all packages belonging to GoogleChrome Package
+GoogleChrome=1
+>>GoogleChrome=1
+>>WebViewGoogle=1
+>>TrichromeLibrary=1
+
+Gmail=0
+DeviceSetup=0
+AndroidAuto=0
+GoogleFeedback=0
+GooglePartnerSetup=0
+AndroidDevicePolicy=0
+
+# Set CoreGo=0 if you want to skip installing all packages belonging to CoreGo Package
+CoreGo=0
+
+# Setting CoreGo=0 will not skip following packages, set them to 0 if you want to skip them  
+GoogleGo=0
+AssistantGo=0
+MapsGo=0
+NavigationGo=0
+GalleryGo=0
+GmailGo=0
+
+# Following are the Addon packages NikGapps supports
+PixelSetupWizard=1
+Meet=0
+GoogleDocs=0
+GoogleSheets=0
+GoogleSlides=0
+YouTube=0
+YouTubeMusic=0
+Books=0
+GoogleTalkback=0
+
+# NikGapps debloater starts here, add all the stuff to add to debloater.config below (for elite and user builds only), check examples below
+# YouTube
+# /system/app/YouTube
+

--- a/10/noobhitler2.config
+++ b/10/noobhitler2.config
@@ -58,7 +58,7 @@ CarrierServices=1
 GoogleClock=1
 
 # Set SetupWizard=0 if you want to skip installing all packages belonging to SetupWizard Package
-SetupWizard=1
+SetupWizard=0
 >>SetupWizard=1
 >>GoogleRestore=1
 >>GoogleOneTimeInitializer=1
@@ -76,7 +76,7 @@ GoogleKeep=0
 # Set PixelSpecifics=0 if you want to skip installing all packages belonging to PixelSpecifics Package
 PixelSpecifics=1
 >>PixelLauncher=0
->>DevicePersonalizationServices=0
+>>DevicePersonalizationServices=1
 >>GoogleWallpaper=1
 
 PlayGames=0


### PR DESCRIPTION
hey i want to use pixel setup wizard.... and i cant understand what should i do with the 'SetupWizar' appset...
though i changed some things according to my understanding right now,, can you please review...

by the way, 2nd last time i had done this: 

SetupWizard=0
>>SetupWizard=0
>>GoogleRestore=0
>>GoogleOneTimeInitializer=0
>>AndroidMigratePrebuilt=0


# Following are the Addon packages NikGapps supports
PixelSetupWizard=1



so doing this game me an error and when i booted rom, the setup wizard failed'... and i could not do anything except swipe through home screen and app drawer
is it because a10 is not supported by pixel setup wizard?
or was my configuration just wrong...
then the next time i switched my configuration and nikgapps admin said there was some issues with my config,,,, so now i have done like that : (see noobhitler2.config) is that correct?
if its not can you please correct it yourself? i'd be really grateful and be able to understand what to actually do to get pixel setup wizard working!