### PR TITLE
Redmi Note 8 (Ginkgo) A14U_Lite_GApps_config

### DIFF
--- a/14/ritu4004_A14.config
+++ b/14/ritu4004_A14.config
@@ -1,0 +1,145 @@
+# NikGapps configuration file
+
+# If you are not sure about the config, just skip making changes to it or comment it by adding # before it
+# visit https://nikgapps.com/misc/2022/02/22/NikGapps-Config.html to read everything about nikgapps
+
+AndroidVersion=14
+
+Version=35
+
+# set this to the directory you want to copy the logs to.
+# for e.g. LogDirectory="/system/etc" will install the logs to /system/etc/nikgapps_logs directory
+# by default it will install it to /sdcard/NikGapps/nikgapps_logs
+LogDirectory=default
+
+# set to /system, /product or /system_ext if you want to force the installation to aforementioned locations
+InstallPartition=default
+
+# set to uninstall if you want to uninstall any google app, also set the value of google app below to -1
+Mode=install
+
+# set WipeDalvikCache=0 if you don't want the installer to wipe dalvik/cache after installing the gapps
+WipeDalvikCache=1
+
+# set WipeRuntimePermissions=1 if you want to wipe runtime permissions
+WipeRuntimePermissions=0
+
+# Addon.d config, set it to 0 to skip the automatic backup/restore while flashing the rom
+ExecuteBackupRestore=1
+
+# if you want to force the installer to use the config from gapps zip file, set below to 1
+UseZipConfig=0
+
+# if you want to overwrite the config located in /sdcard/NikGapps with gapps zip file, set below to 1. Applicable to decrypted storage only
+OverwriteWithZipConfig=0
+
+# set this to 1 if you want to enable gms optimization, careful while doing it, you may experience issues like delayed notification with some Roms
+GmsOptimization=0
+
+# set this to 0 if you want to skip generating nikgapps logs, if you run into issues, enable it and flash the zip again to get the logs
+GenerateLogs=1
+
+# Following are the packages with default configuration
+
+# Set Core=0 if you want to skip installing all packages belonging to Core Package
+Core=1
+>>ExtraFiles=1
+>>GooglePlayStore=1
+>>GoogleServicesFramework=1
+>>GoogleContactsSyncAdapter=1
+>>GoogleCalendarSyncAdapter=1
+>>GmsCore=1
+
+DigitalWellbeing=0
+GoogleMessages=0
+GoogleDialer=0
+GoogleContacts=0
+CarrierServices=0
+GoogleClock=0
+
+# Set SetupWizard=0 if you want to skip installing all packages belonging to SetupWizard Package
+SetupWizard=0
+>>SetupWizard=1
+>>GoogleRestore=1
+>>GoogleOneTimeInitializer=1
+
+GoogleCalculator=0
+Drive=0
+GoogleMaps=0
+GoogleLocationHistory=0
+GooglePhotos=1
+DeviceHealthServices=0
+GBoard=1
+GoogleCalendar=0
+GoogleKeep=0
+
+# Set PixelSpecifics=0 if you want to skip installing all packages belonging to PixelSpecifics Package
+PixelSpecifics=1
+>>PixelLauncher=1
+>>DevicePersonalizationServices=0
+>>GoogleWallpaper=1
+>>QuickAccessWallet=0
+>>SettingsServices=0
+>>PrivateComputeServices=0
+>>PixelThemes=1
+>>EmojiWallpaper=1
+>>PixelWeather=0
+
+PlayGames=0
+GoogleRecorder=1
+
+# Set GoogleFiles=0 if you want to skip installing all packages belonging to GoogleFiles Package
+GoogleFiles=0
+>>GoogleFiles=1
+>>StorageManager=1
+>>DocumentsUIGoogle=1
+
+MarkupGoogle=1
+GoogleTTS=0
+
+# Set GoogleSearch=0 if you want to skip installing all packages belonging to GoogleSearch Package
+GoogleSearch=0
+>>Velvet=1
+>>Assistant=1
+
+GoogleSounds=1
+
+# Set GoogleChrome=0 if you want to skip installing all packages belonging to GoogleChrome Package
+GoogleChrome=1
+>>GoogleChrome=1
+>>WebViewGoogle=1
+>>TrichromeLibrary=1
+
+Gmail=0
+DeviceSetup=0
+AndroidAuto=0
+GoogleFeedback=0
+GooglePartnerSetup=0
+AndroidDevicePolicy=0
+
+# Set CoreGo=0 if you want to skip installing all packages belonging to CoreGo Package
+CoreGo=0
+
+# Setting CoreGo=0 will not skip following packages, set them to 0 if you want to skip them  
+GoogleGo=0
+AssistantGo=0
+MapsGo=0
+NavigationGo=0
+GalleryGo=0
+GmailGo=0
+
+# Following are the Addon packages NikGapps supports
+PixelSetupWizard=0
+Meet=0
+GoogleDocs=0
+GoogleSheets=0
+GoogleSlides=0
+YouTube=0
+YouTubeMusic=0
+Books=0
+GoogleTalkback=0
+
+# NikGapps debloater starts here, add all the stuff to add to debloater.config below (for elite and user builds only), check examples below
+# YouTube
+# /system/app/YouTube
+

--- a/14/ritu4004_A14U_Lite_GApps.config
+++ b/14/ritu4004_A14U_Lite_GApps.config
@@ -1,0 +1,145 @@
+# NikGapps configuration file
+
+# If you are not sure about the config, just skip making changes to it or comment it by adding # before it
+# visit https://nikgapps.com/misc/2022/02/22/NikGapps-Config.html to read everything about nikgapps
+
+AndroidVersion=14
+
+Version=35
+
+# set this to the directory you want to copy the logs to.
+# for e.g. LogDirectory="/system/etc" will install the logs to /system/etc/nikgapps_logs directory
+# by default it will install it to /sdcard/NikGapps/nikgapps_logs
+LogDirectory=default
+
+# set to /system, /product or /system_ext if you want to force the installation to aforementioned locations
+InstallPartition=default
+
+# set to uninstall if you want to uninstall any google app, also set the value of google app below to -1
+Mode=install
+
+# set WipeDalvikCache=0 if you don't want the installer to wipe dalvik/cache after installing the gapps
+WipeDalvikCache=1
+
+# set WipeRuntimePermissions=1 if you want to wipe runtime permissions
+WipeRuntimePermissions=0
+
+# Addon.d config, set it to 0 to skip the automatic backup/restore while flashing the rom
+ExecuteBackupRestore=1
+
+# if you want to force the installer to use the config from gapps zip file, set below to 1
+UseZipConfig=0
+
+# if you want to overwrite the config located in /sdcard/NikGapps with gapps zip file, set below to 1. Applicable to decrypted storage only
+OverwriteWithZipConfig=0
+
+# set this to 1 if you want to enable gms optimization, careful while doing it, you may experience issues like delayed notification with some Roms
+GmsOptimization=0
+
+# set this to 0 if you want to skip generating nikgapps logs, if you run into issues, enable it and flash the zip again to get the logs
+GenerateLogs=1
+
+# Following are the packages with default configuration
+
+# Set Core=0 if you want to skip installing all packages belonging to Core Package
+Core=1
+>>ExtraFiles=1
+>>GooglePlayStore=1
+>>GoogleServicesFramework=1
+>>GoogleContactsSyncAdapter=1
+>>GoogleCalendarSyncAdapter=1
+>>GmsCore=1
+
+DigitalWellbeing=0
+GoogleMessages=0
+GoogleDialer=0
+GoogleContacts=0
+CarrierServices=0
+GoogleClock=0
+
+# Set SetupWizard=0 if you want to skip installing all packages belonging to SetupWizard Package
+SetupWizard=0
+>>SetupWizard=1
+>>GoogleRestore=1
+>>GoogleOneTimeInitializer=1
+
+GoogleCalculator=0
+Drive=0
+GoogleMaps=0
+GoogleLocationHistory=0
+GooglePhotos=1
+DeviceHealthServices=0
+GBoard=1
+GoogleCalendar=0
+GoogleKeep=0
+
+# Set PixelSpecifics=0 if you want to skip installing all packages belonging to PixelSpecifics Package
+PixelSpecifics=0
+>>PixelLauncher=1
+>>DevicePersonalizationServices=0
+>>GoogleWallpaper=1
+>>QuickAccessWallet=0
+>>SettingsServices=0
+>>PrivateComputeServices=0
+>>PixelThemes=1
+>>EmojiWallpaper=1
+>>PixelWeather=0
+
+PlayGames=0
+GoogleRecorder=1
+
+# Set GoogleFiles=0 if you want to skip installing all packages belonging to GoogleFiles Package
+GoogleFiles=0
+>>GoogleFiles=1
+>>StorageManager=1
+>>DocumentsUIGoogle=1
+
+MarkupGoogle=1
+GoogleTTS=0
+
+# Set GoogleSearch=0 if you want to skip installing all packages belonging to GoogleSearch Package
+GoogleSearch=0
+>>Velvet=1
+>>Assistant=1
+
+GoogleSounds=0
+
+# Set GoogleChrome=0 if you want to skip installing all packages belonging to GoogleChrome Package
+GoogleChrome=1
+>>GoogleChrome=1
+>>WebViewGoogle=1
+>>TrichromeLibrary=1
+
+Gmail=0
+DeviceSetup=0
+AndroidAuto=0
+GoogleFeedback=0
+GooglePartnerSetup=0
+AndroidDevicePolicy=0
+
+# Set CoreGo=0 if you want to skip installing all packages belonging to CoreGo Package
+CoreGo=0
+
+# Setting CoreGo=0 will not skip following packages, set them to 0 if you want to skip them  
+GoogleGo=0
+AssistantGo=0
+MapsGo=0
+NavigationGo=0
+GalleryGo=0
+GmailGo=0
+
+# Following are the Addon packages NikGapps supports
+PixelSetupWizard=0
+Meet=0
+GoogleDocs=0
+GoogleSheets=0
+GoogleSlides=0
+YouTube=0
+YouTubeMusic=0
+Books=0
+GoogleTalkback=0
+
+# NikGapps debloater starts here, add all the stuff to add to debloater.config below (for elite and user builds only), check examples below
+# YouTube
+# /system/app/YouTube
+


### PR DESCRIPTION
This GApps created for Android-14 and i am a noobs so this is a least minimum requirement GApps for older devices.

Core	Core packages, required to run the playstore
>>ExtraFiles=1	Package for additional files required to make gapps work

>>GooglePlayStore=1	Google Play Store, also known as Phonesky

>>GoogleServicesFramework=1	The Services Framework, in particular, is used to manage and update the various apps made by Google, as well as any application or game that is downloaded from the Google Play Store

>>GoogleContactsSyncAdapter=1	This package is used to sync the contacts associated to your google account

>>GoogleCalendarSyncAdapter=1	This package is used to sync the calendar events associated to your google account

>>GmsCore=1	Google Play Services - heart of google apps

GooglePhotos=1 	Package for Google Photos app

GBoard=1	Package for Google KeyBoard app

GoogleRecorder=1	Package for Google Recorder app

MarkupGoogle=1	Photos Markup app used in google photos and also to edit the captured screenshots

GoogleChrome=1	Appset that controls GoogleChrome components
>>GoogleChrome=1	Google Chrome Browser
>>WebViewGoogle=1	Webview for opening links from within the app)
>>TrichromeLibrary=1	Chrome Library

