### PR TITLE
Remove GoogleSounds

### DIFF
--- a/elite/15/halogenOS/halogenOS.config
+++ b/elite/15/halogenOS/halogenOS.config
@@ -106,7 +106,7 @@ GoogleSearch=1
 >>Velvet=1
 >>Assistant=1
 
-GoogleSounds=1
+GoogleSounds=0
 
 # Set GoogleChrome=0 if you want to skip installing all packages belonging to GoogleChrome Package
 GoogleChrome=0


### PR DESCRIPTION
Remove GoogleSounds. This is a try to fix the Settings crash when trying to change Ringtones