### PR TITLE
crDroid_A15_fixedbugs.config

### DIFF
--- a/15/crDroid_A15_fixedbugs.config
+++ b/15/crDroid_A15_fixedbugs.config
@@ -1,0 +1,158 @@
+# NikGapps configuration file
+
+# If you are not sure about the config, just skip making changes to it or comment it by adding # before it
+# visit https://nikgapps.com/misc/2022/02/22/NikGapps-Config.html to read everything about nikgapps
+
+PR_NUMBER=7157
+
+PR_NAME=crdroid-official
+
+RELEASE_DATE=2412121896
+
+mode=install
+
+execute.d=1
+
+use_zip_config=1
+
+override_with_zip_config=0
+
+gms_optimization=0
+
+AndroidVersion=15
+
+Version=37
+
+# set this to the directory you want to copy the logs to.
+# for e.g. LogDirectory="/system/etc" will install the logs to /system/etc/nikgapps_logs directory
+# by default it will install it to /sdcard/NikGapps/nikgapps_logs
+LogDirectory=default
+
+# set to /system, /product or /system_ext if you want to force the installation to aforementioned locations
+InstallPartition=default
+
+# set to uninstall if you want to uninstall any google app, also set the value of google app below to -1
+Mode=install
+
+# set WipeDalvikCache=0 if you don't want the installer to wipe dalvik/cache after installing the gapps
+WipeDalvikCache=1
+
+# set WipeRuntimePermissions=1 if you want to wipe runtime permissions
+WipeRuntimePermissions=0
+
+# Addon.d config, set it to 0 to skip the automatic backup/restore while flashing the rom
+ExecuteBackupRestore=1
+
+# if you want to force the installer to use the config from gapps zip file, set below to 1
+UseZipConfig=0
+
+# if you want to overwrite the config located in /sdcard/NikGapps with gapps zip file, set below to 1. Applicable to decrypted storage only
+OverwriteWithZipConfig=0
+
+# set this to 1 if you want to enable gms optimization, careful while doing it, you may experience issues like delayed notification with some Roms
+GmsOptimization=0
+
+# set this to 0 if you want to skip generating nikgapps logs, if you run into issues, enable it and flash the zip again to get the logs
+GenerateLogs=1
+
+# Following are the packages with default configuration
+
+# Set Core=0 if you want to skip installing all packages belonging to Core Package
+Core=1
+>>ExtraFiles=1
+>>GooglePlayStore=1
+>>GoogleServicesFramework=1
+>>GoogleContactsSyncAdapter=1
+>>GoogleCalendarSyncAdapter=1
+>>GmsCore=1
+
+DigitalWellbeing=1
+GoogleMessages=1
+GoogleDialer=0
+GoogleContacts=1
+CarrierServices=1
+GoogleClock=1
+
+# Set SetupWizard=0 if you want to skip installing all packages belonging to SetupWizard Package
+SetupWizard=1
+>>SetupWizard=1
+>>GoogleRestore=1
+>>GoogleOneTimeInitializer=1
+
+GoogleCalculator=0
+Drive=0
+GoogleMaps=0
+GoogleLocationHistory=0
+GooglePhotos=0
+DeviceHealthServices=1
+GBoard=0
+GoogleCalendar=1
+GoogleKeep=1
+
+# Set PixelSpecifics=0 if you want to skip installing all packages belonging to PixelSpecifics Package
+PixelSpecifics=1
+>>PixelLauncher=0
+>>DevicePersonalizationServices=1
+>>GoogleWallpaper=0
+>>QuickAccessWallet=0
+>>SettingsServices=1
+>>PrivateComputeServices=1
+>>PixelThemes=0
+>>EmojiWallpaper=0
+>>PixelWeather=0
+>>AICore=0
+
+PlayGames=0
+GoogleRecorder=0
+
+# Set GoogleFiles=0 if you want to skip installing all packages belonging to GoogleFiles Package
+GoogleFiles=1
+>>GoogleFiles=1
+>>StorageManager=1
+>>DocumentsUIGoogle=1
+
+MarkupGoogle=1
+GoogleTTS=0
+
+# Set GoogleSearch=0 if you want to skip installing all packages belonging to GoogleSearch Package
+GoogleSearch=1
+>>Velvet=1
+>>Assistant=1
+
+GoogleSounds=1
+
+# Set GoogleChrome=0 if you want to skip installing all packages belonging to GoogleChrome Package
+GoogleChrome=0
+>>GoogleChrome=0
+>>WebViewGoogle=0
+>>TrichromeLibrary=0
+
+Gmail=1
+DeviceSetup=1
+AndroidAuto=0
+GoogleFeedback=0
+GooglePartnerSetup=0
+AndroidDevicePolicy=0
+
+# Set CoreGo=0 if you want to skip installing all packages belonging to CoreGo Package
+CoreGo=0
+
+# Setting CoreGo=0 will not skip following packages, set them to 0 if you want to skip them  
+GoogleGo=0
+AssistantGo=0
+MapsGo=0
+NavigationGo=0
+GalleryGo=0
+GmailGo=0
+
+# Following are the Addon packages NikGapps supports
+PixelSetupWizard=0
+Meet=0
+GoogleDocs=0
+GoogleSheets=0
+GoogleSlides=0
+YouTube=0
+YouTubeMusic=0
+Books=0
+GoogleTalkback=0
+GooglePersonalSafety=0


### PR DESCRIPTION
This build is for Android 15 crDroid and Certain package in PixelSpecifics is skipped so that it will not replace the AOSP launcher and cause freeze bugs and launcher crashes.