### PR TITLE
Add custom nikgapps.config with Play Store disabled

### DIFF
--- a/15/nikgapps.config
+++ b/15/nikgapps.config
@@ -1,0 +1,147 @@
+# NikGapps configuration file
+
+# If you are not sure about the config, just skip making changes to it or comment it by adding # before it
+# visit https://nikgapps.com/misc/2022/02/22/NikGapps-Config.html to read everything about nikgapps
+
+AndroidVersion=15
+
+Version=37
+
+# set this to the directory you want to copy the logs to.
+# for e.g. LogDirectory="/system/etc" will install the logs to /system/etc/nikgapps_logs directory
+# by default it will install it to /sdcard/NikGapps/nikgapps_logs
+LogDirectory=default
+
+# set to /system, /product or /system_ext if you want to force the installation to aforementioned locations
+InstallPartition=default
+
+# set to uninstall if you want to uninstall any google app, also set the value of google app below to -1
+Mode=install
+
+# set WipeDalvikCache=0 if you don't want the installer to wipe dalvik/cache after installing the gapps
+WipeDalvikCache=1
+
+# set WipeRuntimePermissions=1 if you want to wipe runtime permissions
+WipeRuntimePermissions=0
+
+# Addon.d config, set it to 0 to skip the automatic backup/restore while flashing the rom
+ExecuteBackupRestore=1
+
+# if you want to force the installer to use the config from gapps zip file, set below to 1
+UseZipConfig=0
+
+# if you want to overwrite the config located in /sdcard/NikGapps with gapps zip file, set below to 1. Applicable to decrypted storage only
+OverwriteWithZipConfig=0
+
+# set this to 1 if you want to enable gms optimization, careful while doing it, you may experience issues like delayed notification with some Roms
+GmsOptimization=0
+
+# set this to 0 if you want to skip generating nikgapps logs, if you run into issues, enable it and flash the zip again to get the logs
+GenerateLogs=1
+
+# Following are the packages with default configuration
+
+# Set Core=0 if you want to skip installing all packages belonging to Core Package
+Core=1
+>>ExtraFiles=1
+>>GooglePlayStore=0
+>>GoogleServicesFramework=1
+>>GoogleContactsSyncAdapter=1
+>>GoogleCalendarSyncAdapter=1
+>>GmsCore=1
+
+DigitalWellbeing=1
+GoogleMessages=1
+GoogleDialer=1
+GoogleContacts=1
+CarrierServices=1
+GoogleClock=1
+
+# Set SetupWizard=0 if you want to skip installing all packages belonging to SetupWizard Package
+SetupWizard=1
+>>SetupWizard=1
+>>GoogleRestore=1
+>>GoogleOneTimeInitializer=1
+
+GoogleCalculator=1
+Drive=1
+GoogleMaps=1
+GoogleLocationHistory=1
+GooglePhotos=1
+DeviceHealthServices=1
+GBoard=1
+GoogleCalendar=1
+GoogleKeep=1
+
+# Set PixelSpecifics=0 if you want to skip installing all packages belonging to PixelSpecifics Package
+PixelSpecifics=1
+>>PixelLauncher=1
+>>DevicePersonalizationServices=1
+>>GoogleWallpaper=1
+>>QuickAccessWallet=1
+>>SettingsServices=1
+>>PrivateComputeServices=1
+>>PixelThemes=1
+>>EmojiWallpaper=1
+>>PixelWeather=1
+>>AICore=1
+
+PlayGames=1
+GoogleRecorder=1
+
+# Set GoogleFiles=0 if you want to skip installing all packages belonging to GoogleFiles Package
+GoogleFiles=1
+>>GoogleFiles=1
+>>StorageManager=1
+>>DocumentsUIGoogle=1
+
+MarkupGoogle=1
+GoogleTTS=1
+
+# Set GoogleSearch=0 if you want to skip installing all packages belonging to GoogleSearch Package
+GoogleSearch=1
+>>Velvet=1
+>>Assistant=1
+
+GoogleSounds=1
+
+# Set GoogleChrome=0 if you want to skip installing all packages belonging to GoogleChrome Package
+GoogleChrome=1
+>>GoogleChrome=1
+>>WebViewGoogle=1
+>>TrichromeLibrary=1
+
+Gmail=1
+DeviceSetup=1
+AndroidAuto=1
+GoogleFeedback=1
+GooglePartnerSetup=1
+AndroidDevicePolicy=1
+
+# Set CoreGo=0 if you want to skip installing all packages belonging to CoreGo Package
+CoreGo=1
+
+# Setting CoreGo=0 will not skip following packages, set them to 0 if you want to skip them  
+GoogleGo=1
+AssistantGo=1
+MapsGo=1
+NavigationGo=1
+GalleryGo=1
+GmailGo=1
+
+# Following are the Addon packages NikGapps supports
+PixelSetupWizard=1
+Meet=1
+GoogleDocs=1
+GoogleSheets=1
+GoogleSlides=1
+YouTube=1
+YouTubeMusic=1
+Books=1
+GoogleTalkback=1
+GooglePersonalSafety=1
+
+# NikGapps debloater starts here, add all the stuff to add to debloater.config below (for elite and user builds only), check examples below
+# YouTube
+# /system/app/YouTube
+


### PR DESCRIPTION
This configuration disables the Google Play Store package while keeping essential Google services enabled for Android 15. This allows using MicroG or minimal Google services without the Play Store.
